### PR TITLE
Propagate errors sent by the website.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,8 @@ impl AoC {
                 self.year, day
             ))
             .header(COOKIE, format!("session={}", self.token))
-            .send()?;
+            .send()?
+            .error_for_status()?;
         res.text()
     }
 


### PR DESCRIPTION
Currently if the website returns an http error the payload of the response is still cached and returned to the caller. This pr fixes that.