### PR TITLE
wait for puzzle release before fetching

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "MPL-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+chrono = "0.4.23"
 dirs = "4.0.0"
 reqwest = { version = "0.11.13", features = ["blocking", "rustls-tls"], default-features = false }
 thiserror = "1.0.37"


### PR DESCRIPTION
Technically this is a breaking change because it adds new error variants (and we're not using [non_exhaustive](https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute)). I don't think anyone will mind.